### PR TITLE
Unsync encounter object to server

### DIFF
--- a/mitplan-frontend/src/components/Sheet/EncounterSelect.tsx
+++ b/mitplan-frontend/src/components/Sheet/EncounterSelect.tsx
@@ -41,7 +41,7 @@ const EncounterSelect: React.FC<EncounterSelectProps> = ({ mitplanId }) => {
         dispatch(updateSheet({
           mitplanId,
           sheetId: activeSheetId,
-          updates: { encounter }
+          updates: { encounterId: selectedEncounter }
         }));
         console.log(`Updated encounter to ${encounter.name} for mitplan ${mitplanId}, sheet ${activeSheetId}`); // Debug log
       } else {

--- a/mitplan-frontend/src/components/Sheet/Sheet.tsx
+++ b/mitplan-frontend/src/components/Sheet/Sheet.tsx
@@ -14,7 +14,7 @@ const SheetComponent: React.FC<SheetType & {
 }> = ({
   name,
   assignmentEvents,
-  encounter,
+  encounterId,
   columnCount,
   mitplanId,
   sheetId,

--- a/mitplan-frontend/src/components/Sheet/VerticalTimeline.tsx
+++ b/mitplan-frontend/src/components/Sheet/VerticalTimeline.tsx
@@ -7,6 +7,7 @@ import EventColumn from './EventColumn';
 import CustomDragLayer from './CustomDragLayer';
 import TimestampColumn from './TimestampColumn';
 import CooldownPalette from './CooldownPalette';
+import { allEncounters } from '../../data/encounters/encounters';
 
 interface VerticalTimelineProps {
   mitplanId: string;
@@ -19,7 +20,10 @@ const VerticalTimeline: React.FC<VerticalTimelineProps> = ({ mitplanId, sheetId 
   const containerRef = useRef<HTMLDivElement>(null);
 
   const sheet = useSelector((state: RootState) => state.mitplans.mitplans[mitplanId]?.sheets[sheetId]);
-  const { assignmentEvents, encounter, columnCount, timeScale = 5 } = sheet || {};
+  const { assignmentEvents, encounterId, columnCount, timeScale = 5 } = sheet || {};
+  const encounter = allEncounters[encounterId];
+  console.log(encounterId);
+  console.log('XXXXXXXXXXXXXaaaaaaaaaaaaaaaaaAXXXXXXXXXXXXXXXXXXXXX');
 
   const updateSheetEvents = useCallback((updatedEvents: { [id: string]: AssignmentEventType }) => {
     const newEvents = { ...assignmentEvents, ...updatedEvents };

--- a/mitplan-frontend/src/components/Sheet/VerticalTimeline.tsx
+++ b/mitplan-frontend/src/components/Sheet/VerticalTimeline.tsx
@@ -22,8 +22,6 @@ const VerticalTimeline: React.FC<VerticalTimelineProps> = ({ mitplanId, sheetId 
   const sheet = useSelector((state: RootState) => state.mitplans.mitplans[mitplanId]?.sheets[sheetId]);
   const { assignmentEvents, encounterId, columnCount, timeScale = 5 } = sheet || {};
   const encounter = allEncounters[encounterId];
-  console.log(encounterId);
-  console.log('XXXXXXXXXXXXXaaaaaaaaaaaaaaaaaAXXXXXXXXXXXXXXXXXXXXX');
 
   const updateSheetEvents = useCallback((updatedEvents: { [id: string]: AssignmentEventType }) => {
     const newEvents = { ...assignmentEvents, ...updatedEvents };

--- a/mitplan-frontend/src/components/SheetNavigation.tsx
+++ b/mitplan-frontend/src/components/SheetNavigation.tsx
@@ -32,8 +32,6 @@ const SheetNavigation: React.FC<SheetNavigationProps> = ({
 
   const handleCreateSheet = () => {
     const newSheetId = uuidv4();
-    const defaultEncounterId = Object.keys(allEncounters)[0];
-    const defaultEncounter = allEncounters[defaultEncounterId];
 
     dispatch(addSheet({
       mitplanId,
@@ -41,7 +39,7 @@ const SheetNavigation: React.FC<SheetNavigationProps> = ({
         id: newSheetId,
         name: `New Sheet ${Object.keys(sheets || {}).length + 1}`,
         assignmentEvents: {},
-        encounter: defaultEncounter,
+        encounterId: 'Default',
         columnCount: 5,
         timeScale: 1,
       }

--- a/mitplan-frontend/src/store/mitplansSlice.ts
+++ b/mitplan-frontend/src/store/mitplansSlice.ts
@@ -116,7 +116,7 @@ const mitplansSlice = createSlice({
       state.mitplans[mitplanId].sheets[sheet.id] = {
         ...sheet,
         assignmentEvents: sheet.assignmentEvents || {},
-        encounter: sheet.encounter || getDefaultEncounter()
+        encounterId: sheet.encounterId || 'Default'
       };
       updateServerState(mitplanId, getServerSyncedState(state.mitplans[mitplanId]));
     },
@@ -135,7 +135,7 @@ const mitplansSlice = createSlice({
         ...currentSheet, 
         ...updates,
         assignmentEvents: updates.assignmentEvents || currentSheet.assignmentEvents || {},
-        encounter: updates.encounter || currentSheet.encounter || getDefaultEncounter()
+        encounterId: updates.encounterId || currentSheet.encounterId || 'Default'
       };
       updateServerState(mitplanId, getServerSyncedState(state.mitplans[mitplanId]));
     },
@@ -286,7 +286,6 @@ const mitplansSlice = createSlice({
               id: defaultSheetId,
               name: 'Sheet 1',
               assignmentEvents: {},
-              encounter: getDefaultEncounter(),
               encounterId: 'Default',
               columnCount: 5,
               timeScale: 5.4

--- a/mitplan-frontend/src/store/mitplansSlice.ts
+++ b/mitplan-frontend/src/store/mitplansSlice.ts
@@ -287,6 +287,7 @@ const mitplansSlice = createSlice({
               name: 'Sheet 1',
               assignmentEvents: {},
               encounter: getDefaultEncounter(),
+              encounterId: 'Default',
               columnCount: 5,
               timeScale: 5.4
             }

--- a/mitplan-frontend/src/types/index.ts
+++ b/mitplan-frontend/src/types/index.ts
@@ -52,7 +52,6 @@ export interface ServerSyncedSheet {
   id: string;
   name: string;
   assignmentEvents: { [id: string]: AssignmentEventType };
-  encounter: Encounter;
   encounterId: string;
   columnCount: number;
 }

--- a/mitplan-frontend/src/types/index.ts
+++ b/mitplan-frontend/src/types/index.ts
@@ -53,6 +53,7 @@ export interface ServerSyncedSheet {
   name: string;
   assignmentEvents: { [id: string]: AssignmentEventType };
   encounter: Encounter;
+  encounterId: string;
   columnCount: number;
 }
 


### PR DESCRIPTION
This change feels stupid and convoluted for what its trying to do. When the server receives the sheet it removes the encounter and replaces it with an encounterId. When the server sends data it first converts the encounterId to an encounter and then sends the encounter. I don't think this is what you want at all but have a look at it anyways.